### PR TITLE
expose `cloneWithWhitelist` to deal with non-standard AST trees

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,34 @@ Leaves properties defined in [The ESTree Spec](https://github.com/estree/estree)
 `espurify` supports [ES5](https://github.com/estree/estree/blob/master/spec.md) and [ES6](https://github.com/estree/estree/blob/master/es6.md) properties.
 
 
+### var customizedCloneFunctionWithWhiteList = espurify.cloneWithWhitelist(whiteList)
+
+Returns customized function for cloning AST, with user-provided `whiteList`.
+
+
+### var purifiedAstClone = customizedCloneFunctionWithWhiteList(originalAst)
+
+Returns new clone of `originalAst` by customized function.
+
+
+#### whiteList
+
+| type     | default value |
+|:---------|:--------------|
+| `object` | N/A           |
+
+`whiteList` is an object containing NodeType as keys and properties as values.
+
+```js
+{
+    ArrayExpression: ['type', 'elements'],
+    ArrayPattern: ['type', 'elements'],
+    ArrowFunctionExpression: ['type', 'id', 'params', 'body', 'generator', 'expression'],
+    AssignmentExpression: ['type', 'operator', 'left', 'right'],
+    ...
+```
+
+
 ### var customizedCloneFunction = espurify.customize(options)
 
 Returns customized function for cloning AST, configured by custom `options`.

--- a/index.js
+++ b/index.js
@@ -18,4 +18,5 @@ function createCloneFunction (options) {
 
 var espurify = createCloneFunction();
 espurify.customize = createCloneFunction;
+espurify.cloneWithWhitelist = cloneWithWhitelist;
 module.exports = espurify;

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "xtend": "^4.0.0"
   },
   "devDependencies": {
+    "babel-types": "^6.3.20",
+    "babylon": "^6.3.20",
     "browserify": "^11.1.0",
     "derequire": "^2.0.2",
     "dereserve": "^0.1.1",

--- a/test/fixtures/CounterContainer.jsx
+++ b/test/fixtures/CounterContainer.jsx
@@ -1,0 +1,37 @@
+import {Component} from 'react';
+import {Container} from 'flux/utils';
+
+type CounterStoreStateType = {counter: number};
+type CounterContainerStateType = {
+    qty: number,
+    total: number
+};
+
+class CounterContainer extends Component {
+  static getStores(): Array<Store> {
+    return [CounterStore];
+  }
+
+  static calculateState(prevState: CounterStoreStateType): CounterStoreStateType {
+    return {
+      counter: CounterStore.getState(),
+    };
+  }
+
+  static propTypes = {
+    title: React.PropTypes.string.isRequired,
+    price: React.PropTypes.number.isRequired,
+    initialQty: React.PropTypes.number
+  };
+
+  state: CounterContainerStateType = {
+    qty: this.props.initialQty,
+    total: 0
+  };
+
+  render() {
+    return <CounterUI counter={this.state.counter} />;
+  }
+}
+
+const container: CounterContainer = Container.create(CounterContainer);


### PR DESCRIPTION
expose `cloneWithWhitelist` function to deal with non-standard AST trees such as Babel produced trees.

- [x] implement
- [x] test
- [x] docs
