### PR TITLE
Improve AST clone performance

### DIFF
--- a/lib/clone-ast.js
+++ b/lib/clone-ast.js
@@ -21,17 +21,15 @@ module.exports = function cloneWithWhitelist (astWhiteList) {
     }
 
     function cloneContainer (collector, obj) {
-        if (isArray(obj)) {
-            return cloneArray(collector, obj);
-        } else if (obj.type && whitelist[obj.type]) {
+        if (obj.type && whitelist[obj.type]) {
             return cloneNode(collector, obj);
         } else {
             return cloneObj(collector, obj);
         }
     }
 
-    function cloneArray (collector, ary) {
-        var i, len;
+    function cloneArray (ary) {
+        var i, len, collector = [];
         for (i = 0, len = ary.length; i < len; i += 1) {
             collector.push(cloneOf(ary[i]));
         }
@@ -64,8 +62,10 @@ module.exports = function cloneWithWhitelist (astWhiteList) {
         if (typeof val === 'object' && val !== null) {
             if (val instanceof RegExp) {
                 return new RegExp(val);
+            } else if (isArray(val)) {
+                return cloneArray(val);
             } else {
-                return cloneContainer(isArray(val) ? [] : {}, val);
+                return cloneContainer({}, val);
             }
         } else {
             return val;

--- a/lib/clone-ast.js
+++ b/lib/clone-ast.js
@@ -22,6 +22,14 @@ module.exports = function cloneWithWhitelist (astWhiteList) {
         }
     }
 
+    function cloneArray (ary) {
+        var i = ary.length, clone = [];
+        while (i--) {
+            clone[i] = cloneOf(ary[i]);
+        }
+        return clone;
+    }
+
     function cloneNode (node, props) {
         var i, len, key, clone = {};
         for (i = 0, len = props.length; i < len; i += 1) {
@@ -39,14 +47,6 @@ module.exports = function cloneWithWhitelist (astWhiteList) {
         for (i = 0, len = props.length; i < len; i += 1) {
             key = props[i];
             clone[key] = cloneOf(obj[key]);
-        }
-        return clone;
-    }
-
-    function cloneArray (ary) {
-        var i = ary.length, clone = [];
-        while (i--) {
-            clone[i] = cloneOf(ary[i]);
         }
         return clone;
     }

--- a/lib/clone-ast.js
+++ b/lib/clone-ast.js
@@ -18,9 +18,9 @@ module.exports = function cloneWithWhitelist (astWhiteList) {
 
     function cloneContainer (obj) {
         if (obj.type && whitelist[obj.type]) {
-            return cloneNode(obj);
+            return cloneProps(obj, whitelist[obj.type]);
         } else {
-            return cloneObj(obj);
+            return cloneProps(obj, objectKeys(obj));
         }
     }
 
@@ -32,18 +32,10 @@ module.exports = function cloneWithWhitelist (astWhiteList) {
         return collector;
     }
 
-    function cloneNode (obj) {
-        var i, len, props = whitelist[obj.type], collector = {};
+    function cloneProps (obj, props) {
+        var i, len, collector = {};
         for (i = 0, len = props.length; i < len; i += 1) {
             cloneProperty(collector, obj, props[i]);
-        }
-        return collector;
-    }
-
-    function cloneObj (obj) {
-        var key, collector = {};
-        for (key in obj) {
-            cloneProperty(collector, obj, key);
         }
         return collector;
     }

--- a/lib/clone-ast.js
+++ b/lib/clone-ast.js
@@ -34,17 +34,14 @@ module.exports = function cloneWithWhitelist (astWhiteList) {
     }
 
     function cloneProps (obj, props) {
-        var i, len, collector = {};
+        var i, len, key, collector = {};
         for (i = 0, len = props.length; i < len; i += 1) {
-            cloneProperty(collector, obj, props[i]);
+            key = props[i];
+            if (obj.hasOwnProperty(key)) {
+                collector[key] = cloneOf(obj[key]);
+            }
         }
         return collector;
-    }
-
-    function cloneProperty (collector, obj, key) {
-        if (obj.hasOwnProperty(key)) {
-            collector[key] = cloneOf(obj[key]);
-        }
     }
 
     function cloneOf (val) {

--- a/lib/clone-ast.js
+++ b/lib/clone-ast.js
@@ -13,7 +13,7 @@ module.exports = function cloneWithWhitelist (astWhiteList) {
         return props;
     }, {});
 
-    function cloneContainer (obj) {
+    function cloneObject (obj) {
         var props = obj.type ? whitelist[obj.type] : null;
         if (props) {
             return cloneProps(obj, props);
@@ -48,12 +48,12 @@ module.exports = function cloneWithWhitelist (astWhiteList) {
             } else if (isArray(val)) {
                 return cloneArray(val);
             } else {
-                return cloneContainer(val);
+                return cloneObject(val);
             }
         } else {
             return val;
         }
     }
 
-    return cloneContainer;
+    return cloneObject;
 };

--- a/lib/clone-ast.js
+++ b/lib/clone-ast.js
@@ -13,12 +13,12 @@ module.exports = function cloneWithWhitelist (astWhiteList) {
         return props;
     }, {});
 
-    function cloneObject (obj) {
+    function cloneNodeOrObject (obj) {
         var props = obj.type ? whitelist[obj.type] : null;
         if (props) {
-            return cloneProps(obj, props);
+            return cloneNode(obj, props);
         } else {
-            return cloneProps(obj, objectKeys(obj));
+            return cloneObject(obj);
         }
     }
 
@@ -30,13 +30,23 @@ module.exports = function cloneWithWhitelist (astWhiteList) {
         return collector;
     }
 
-    function cloneProps (obj, props) {
+    function cloneNode (obj, props) {
         var i, len, key, collector = {};
         for (i = 0, len = props.length; i < len; i += 1) {
             key = props[i];
             if (obj.hasOwnProperty(key)) {
                 collector[key] = cloneOf(obj[key]);
             }
+        }
+        return collector;
+    }
+
+    function cloneObject (obj) {
+        var props = objectKeys(obj);
+        var i, len, key, collector = {};
+        for (i = 0, len = props.length; i < len; i += 1) {
+            key = props[i];
+            collector[key] = cloneOf(obj[key]);
         }
         return collector;
     }
@@ -48,12 +58,12 @@ module.exports = function cloneWithWhitelist (astWhiteList) {
             } else if (isArray(val)) {
                 return cloneArray(val);
             } else {
-                return cloneObject(val);
+                return cloneNodeOrObject(val);
             }
         } else {
             return val;
         }
     }
 
-    return cloneObject;
+    return cloneNodeOrObject;
 };

--- a/lib/clone-ast.js
+++ b/lib/clone-ast.js
@@ -26,9 +26,9 @@ module.exports = function cloneWithWhitelist (astWhiteList) {
     }
 
     function cloneArray (ary) {
-        var i, len, collector = [];
-        for (i = 0, len = ary.length; i < len; i += 1) {
-            collector.push(cloneOf(ary[i]));
+        var i = ary.length, collector = [];
+        while (i--) {
+            collector[i] = cloneOf(ary[i]);
         }
         return collector;
     }

--- a/lib/clone-ast.js
+++ b/lib/clone-ast.js
@@ -7,12 +7,9 @@ var reduce = require('array-reduce');
 
 module.exports = function cloneWithWhitelist (astWhiteList) {
     var whitelist = reduce(objectKeys(astWhiteList), function (props, key) {
-        var currentProps = astWhiteList[key];
-        var prepend = [];
-        if (indexOf(currentProps, 'type') === -1) {
-            prepend.push('type');
-        }
-        props[key] = prepend.concat(currentProps);
+        var propNames = astWhiteList[key];
+        var prepend = (indexOf(propNames, 'type') === -1) ? ['type'] : [];
+        props[key] = prepend.concat(propNames);
         return props;
     }, {});
 

--- a/lib/clone-ast.js
+++ b/lib/clone-ast.js
@@ -16,10 +16,6 @@ module.exports = function cloneWithWhitelist (astWhiteList) {
         return props;
     }, {});
 
-    function cloneRoot (ast) {
-        return cloneContainer(ast);
-    }
-
     function cloneContainer (obj) {
         if (obj.type && whitelist[obj.type]) {
             return cloneNode(obj);
@@ -72,5 +68,5 @@ module.exports = function cloneWithWhitelist (astWhiteList) {
         }
     }
 
-    return cloneRoot;
+    return cloneContainer;
 };

--- a/lib/clone-ast.js
+++ b/lib/clone-ast.js
@@ -17,8 +17,9 @@ module.exports = function cloneWithWhitelist (astWhiteList) {
     }, {});
 
     function cloneContainer (obj) {
-        if (obj.type && whitelist[obj.type]) {
-            return cloneProps(obj, whitelist[obj.type]);
+        var props = obj.type ? whitelist[obj.type] : null;
+        if (props) {
+            return cloneProps(obj, props);
         } else {
             return cloneProps(obj, objectKeys(obj));
         }

--- a/lib/clone-ast.js
+++ b/lib/clone-ast.js
@@ -17,14 +17,14 @@ module.exports = function cloneWithWhitelist (astWhiteList) {
     }, {});
 
     function cloneRoot (ast) {
-        return cloneContainer({}, ast);
+        return cloneContainer(ast);
     }
 
-    function cloneContainer (collector, obj) {
+    function cloneContainer (obj) {
         if (obj.type && whitelist[obj.type]) {
-            return cloneNode(collector, obj);
+            return cloneNode(obj);
         } else {
-            return cloneObj(collector, obj);
+            return cloneObj(obj);
         }
     }
 
@@ -36,16 +36,16 @@ module.exports = function cloneWithWhitelist (astWhiteList) {
         return collector;
     }
 
-    function cloneNode (collector, obj) {
-        var i, len, props = whitelist[obj.type];
+    function cloneNode (obj) {
+        var i, len, props = whitelist[obj.type], collector = {};
         for (i = 0, len = props.length; i < len; i += 1) {
             cloneProperty(collector, obj, props[i]);
         }
         return collector;
     }
 
-    function cloneObj (collector, obj) {
-        var key;
+    function cloneObj (obj) {
+        var key, collector = {};
         for (key in obj) {
             cloneProperty(collector, obj, key);
         }
@@ -65,7 +65,7 @@ module.exports = function cloneWithWhitelist (astWhiteList) {
             } else if (isArray(val)) {
                 return cloneArray(val);
             } else {
-                return cloneContainer({}, val);
+                return cloneContainer(val);
             }
         } else {
             return val;

--- a/lib/clone-ast.js
+++ b/lib/clone-ast.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var isArray = require('isarray');
-var objectKeys = require('object-keys');
+var objectKeys = Object.keys || require('object-keys');
 var indexOf = require('indexof');
 var reduce = require('array-reduce');
 

--- a/lib/clone-ast.js
+++ b/lib/clone-ast.js
@@ -22,33 +22,33 @@ module.exports = function cloneWithWhitelist (astWhiteList) {
         }
     }
 
-    function cloneArray (ary) {
-        var i = ary.length, collector = [];
-        while (i--) {
-            collector[i] = cloneOf(ary[i]);
-        }
-        return collector;
-    }
-
-    function cloneNode (obj, props) {
-        var i, len, key, collector = {};
+    function cloneNode (node, props) {
+        var i, len, key, clone = {};
         for (i = 0, len = props.length; i < len; i += 1) {
             key = props[i];
-            if (obj.hasOwnProperty(key)) {
-                collector[key] = cloneOf(obj[key]);
+            if (node.hasOwnProperty(key)) {
+                clone[key] = cloneOf(node[key]);
             }
         }
-        return collector;
+        return clone;
     }
 
     function cloneObject (obj) {
         var props = objectKeys(obj);
-        var i, len, key, collector = {};
+        var i, len, key, clone = {};
         for (i = 0, len = props.length; i < len; i += 1) {
             key = props[i];
-            collector[key] = cloneOf(obj[key]);
+            clone[key] = cloneOf(obj[key]);
         }
-        return collector;
+        return clone;
+    }
+
+    function cloneArray (ary) {
+        var i = ary.length, clone = [];
+        while (i--) {
+            clone[i] = cloneOf(ary[i]);
+        }
+        return clone;
     }
 
     function cloneOf (val) {

--- a/lib/create-whitelist.js
+++ b/lib/create-whitelist.js
@@ -11,7 +11,7 @@ module.exports = function createWhitelist (options) {
     var result = {};
     for (i = 0, len = keys.length; i < len; i += 1) {
         typeName = keys[i];
-        result[typeName] = [].concat(defaultProps[typeName]).concat(opts.extra);
+        result[typeName] = defaultProps[typeName].concat(opts.extra);
     }
     return result;
 };

--- a/lib/create-whitelist.js
+++ b/lib/create-whitelist.js
@@ -1,11 +1,11 @@
 'use strict';
 
 var defaultProps = require('./ast-properties');
-var objectKeys = require('object-keys');
-var extend = require('xtend');
+var objectKeys = Object.keys || require('object-keys');
+var assign = require('object-assign');
 
 module.exports = function createWhitelist (options) {
-    var opts = extend({}, options);
+    var opts = assign({}, options);
     var typeName, i, len;
     var keys = objectKeys(defaultProps);
     var result = {};

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "array-reduce": "0.0.0",
     "indexof": "0.0.1",
     "isarray": "^1.0.0",
-    "object-keys": "^1.0.4",
-    "xtend": "^4.0.0"
+    "object-assign": "^4.0.1",
+    "object-keys": "^1.0.4"
   },
   "devDependencies": {
     "babel-types": "^6.3.20",


### PR DESCRIPTION
Trying to improve AST clone performance more and more.

```
$ node bench_deep_tree.js
clone x 1.59 ops/sec ±1.18% (8 runs sampled)
1.1.0 x 14.56 ops/sec ±3.46% (38 runs sampled)
1.5.0 x 483 ops/sec ±1.12% (85 runs sampled)
head  x 525 ops/sec ±1.06% (86 runs sampled)
Fastest is head
$ 
```

- 8.7% faster than previous version (espurify 1.5.0)
- 36x faster than espurify 1.1.0
- 330x faster than npm clone module!

by [Benchmark.js](https://benchmarkjs.com/)