### PR TITLE
Remove core-js dependency.

### DIFF
--- a/lib/clone-ast.js
+++ b/lib/clone-ast.js
@@ -1,15 +1,9 @@
 'use strict';
 
-var isArray = require('core-js/library/fn/array/is-array');
-var objectKeys = require('core-js/library/fn/object/keys');
-var indexOf = require('core-js/library/fn/array/index-of');
-var Map = require('core-js/library/fn/map');
-var reduce = require('core-js/library/fn/array/reduce');
-
 module.exports = function cloneWithWhitelist (astWhiteList) {
-  var whitelist = reduce(objectKeys(astWhiteList), function (props, key) {
+  var whitelist = Object.keys(astWhiteList).reduce(function (props, key) {
     var propNames = astWhiteList[key];
-    var prepend = (indexOf(propNames, 'type') === -1) ? ['type'] : [];
+    var prepend = (propNames.indexOf('type') === -1) ? ['type'] : [];
     props[key] = prepend.concat(propNames || []);
     return props;
   }, {});
@@ -45,7 +39,7 @@ module.exports = function cloneWithWhitelist (astWhiteList) {
   }
 
   function cloneObject (obj, seen) {
-    var props = objectKeys(obj);
+    var props = Object.keys(obj);
     var i, len, key, value;
     var clone = {};
     for (i = 0, len = props.length; i < len; i += 1) {
@@ -64,7 +58,7 @@ module.exports = function cloneWithWhitelist (astWhiteList) {
       seen.set(val, true);
       if (val instanceof RegExp) {
         return new RegExp(val);
-      } else if (isArray(val)) {
+      } else if (Array.isArray(val)) {
         return cloneArray(val, seen);
       } else {
         return cloneNodeOrObject(val, seen);

--- a/lib/create-whitelist.js
+++ b/lib/create-whitelist.js
@@ -1,13 +1,11 @@
 'use strict';
 
 var defaultProps = require('./ast-properties');
-var objectKeys = require('core-js/library/fn/object/keys');
-var assign = require('core-js/library/fn/object/assign');
 
 module.exports = function createWhitelist (options) {
-  var opts = assign({}, options);
+  var opts = options || {};
   var typeName, i, len;
-  var keys = objectKeys(defaultProps);
+  var keys = Object.keys(defaultProps);
   var result = {};
   for (i = 0, len = keys.length; i < len; i += 1) {
     typeName = keys[i];

--- a/package-lock.json
+++ b/package-lock.json
@@ -702,7 +702,8 @@
     "core-js": {
       "version": "2.5.7",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,7 @@
     "url": "https://github.com/twada"
   },
   "bugs": "https://github.com/estools/espurify/issues",
-  "dependencies": {
-    "core-js": "^2.0.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "acorn": "^5.0.0",
     "babel-types": "^6.3.20",


### PR DESCRIPTION
Similarly to https://github.com/twada/call-matcher/pull/2,
core-js accounts for the vast majority of the install size of
espurify.

Most of these functions are supported in recent Node versions (from the
past few years), so it might be worth it to drop the ponyfills.

Map and Object.assign are only supported in Node 4 and up. The
Object.assign call was not strictly necessary (it was used to clone an
object, but the original would not be modified by espurify), so I
removed it. I also removed the Map import here, so Node 4 is required
with this patch; that may be a breaking change so it may be better to
depend on a (different) polyfill.

Lmk if the above is ok with you (and whether this is something you're
open to at all)