### PR TITLE
Fix cloning when the same object instance is referenced from multiple nodes (and introduce structural cloning)

### DIFF
--- a/lib/clone-ast.js
+++ b/lib/clone-ast.js
@@ -8,60 +8,69 @@ module.exports = function cloneWithWhitelist (astWhiteList) {
     return props;
   }, {});
 
-  function cloneNodeOrObject (obj, seen) {
+  function cloneNodeOrObject (clone, obj, seen) {
     var props = obj.type ? whitelist[obj.type] : null;
     if (props) {
-      return cloneNode(obj, props, seen);
+      return cloneNode(clone, obj, props, seen);
     } else {
-      return cloneObject(obj, seen);
+      return cloneObject(clone, obj, seen);
     }
   }
 
-  function cloneArray (ary, seen) {
+  function cloneArray (clone, ary, seen) {
     var i = ary.length;
-    var clone = [];
     while (i--) {
-      clone[i] = cloneOf(ary[i], seen);
-    }
-    return clone;
-  }
-
-  function cloneNode (node, props, seen) {
-    var i, len, key;
-    var clone = {};
-    for (i = 0, len = props.length; i < len; i += 1) {
-      key = props[i];
-      if (node.hasOwnProperty(key)) {
-        clone[key] = cloneOf(node[key], seen);
+      if (seen.has(ary[i])) {
+        clone[i] = seen.get(ary[i]);
+      } else {
+        clone[i] = cloneOf(ary[i], seen);
       }
     }
     return clone;
   }
 
-  function cloneObject (obj, seen) {
+  function cloneNode (clone, node, props, seen) {
+    var i, len, key;
+    for (i = 0, len = props.length; i < len; i += 1) {
+      key = props[i];
+      if (node.hasOwnProperty(key)) {
+        if (seen.has(node[key])) {
+          clone[key] = seen.get(node[key]);
+        } else {
+          clone[key] = cloneOf(node[key], seen);
+        }
+      }
+    }
+    return clone;
+  }
+
+  function cloneObject (clone, obj, seen) {
     var props = Object.keys(obj);
     var i, len, key, value;
-    var clone = {};
     for (i = 0, len = props.length; i < len; i += 1) {
       key = props[i];
       value = obj[key];
       if (seen.has(value)) {
-        continue;
+        clone[key] = seen.get(value);
+      } else {
+        clone[key] = cloneOf(value, seen);
       }
-      clone[key] = cloneOf(value, seen);
     }
     return clone;
   }
 
   function cloneOf (val, seen) {
     if (typeof val === 'object' && val !== null) {
-      seen.set(val, true);
       if (val instanceof RegExp) {
         return new RegExp(val);
       } else if (Array.isArray(val)) {
-        return cloneArray(val, seen);
+        var clone = [];
+        seen.set(val, clone);
+        return cloneArray(clone, val, seen);
       } else {
-        return cloneNodeOrObject(val, seen);
+        var clone = {};
+        seen.set(val, clone);
+        return cloneNodeOrObject(clone, val, seen);
       }
     } else {
       return val;
@@ -70,8 +79,9 @@ module.exports = function cloneWithWhitelist (astWhiteList) {
 
   function cloneRoot (obj) {
     var seen = new Map();
-    seen.set(obj, true);
-    return cloneNodeOrObject(obj, seen);
+    var clone = {};
+    seen.set(obj, clone);
+    return cloneNodeOrObject(clone, obj, seen);
   }
 
   return cloneRoot;

--- a/test/test.js
+++ b/test/test.js
@@ -668,7 +668,7 @@ describe('dealing with circular references in AST', function () {
     id.parent = root;
     right.parent = root;
 
-    assert.deepEqual(espurify(root), {
+    var expected = {
       type: 'TypeAlias',
       id: {
         type: 'Identifier',
@@ -702,6 +702,13 @@ describe('dealing with circular references in AST', function () {
         indexers: [],
         callProperties: []
       }
-    });
+    };
+    expected.right.parent = expected;
+    expected.right.properties[0].parent = expected.right;
+    expected.right.properties[0].value.parent = expected.right.properties[0];
+    expected.right.properties[1].parent = expected.right;
+    expected.right.properties[1].value.parent = expected.right.properties[1];
+
+    assert.deepEqual(espurify(root), expected);
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -531,6 +531,40 @@ describe('cloneWithWhitelist', function () {
   });
 });
 
+it('should not break when the same object instance is referenced twice', function () {
+  var loc = { start: { line: 4, column: 0 }, end: { line: 4, column: 9 } };
+  var root = {
+    type: 'Program',
+    sourceType: 'script',
+    body: [
+      {
+        type: 'DebuggerStatement',
+        loc
+      },
+      {
+        type: 'DebuggerStatement',
+        loc
+      }
+    ]
+  };
+
+  var clone = espurify.customize({extra: ['loc']});
+  assert.deepEqual(clone(root), {
+    type: 'Program',
+    sourceType: 'script',
+    body: [
+      {
+        type: 'DebuggerStatement',
+        loc
+      },
+      {
+        type: 'DebuggerStatement',
+        loc
+      }
+    ]
+  });
+});
+
 describe('dealing with circular references in AST', function () {
   it('circular references in standard node tree', function () {
     var ident = {


### PR DESCRIPTION
I ran into a problem with purifying some asts created by `espree`, where the `loc` property of multiple nodes will refer to the same object instance. This currently causes some of the cloned `loc` objects to come out empty -- see the failing test introduced in the first commit.

Looked into fixing it and found that the `seen` `Map` was actually used as a `Set` instead of holding the already cloned value, which seemed like a missed opportunity, so I tried implementing that. It required creating the clone before recursing in several cases.