### PR TITLE
Rename all WhiteList to AllowList

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Leaves properties defined in [The ESTree Spec](https://github.com/estree/estree)
 
 
 ### const customizedCloneFunctionWithAllowList = espurify.cloneWithAllowlist(allowList)
-(note: `espurify.cloneWithWhitelist` is depracated in favor of more inclusive language)
+(note: `espurify.cloneWithWhitelist` is deprecated in favor of more inclusive language)
 
 Returns customized function for cloning AST, with user-provided `allowList`.
 

--- a/README.md
+++ b/README.md
@@ -31,23 +31,24 @@ Leaves properties defined in [The ESTree Spec](https://github.com/estree/estree)
 - [ES2022](https://github.com/estree/estree/blob/master/es2022.md)
 
 
-### const customizedCloneFunctionWithWhiteList = espurify.cloneWithWhitelist(whiteList)
+### const customizedCloneFunctionWithAllowList = espurify.cloneWithAllowlist(allowList)
+(note: `espurify.cloneWithWhitelist` is depracated in favor of more inclusive language)
 
-Returns customized function for cloning AST, with user-provided `whiteList`.
+Returns customized function for cloning AST, with user-provided `allowList`.
 
 
-### const purifiedAstClone = customizedCloneFunctionWithWhiteList(originalAst)
+### const purifiedAstClone = customizedCloneFunctionWithAllowList(originalAst)
 
 Returns new clone of `originalAst` by customized function.
 
 
-#### whiteList
+#### allowList
 
 | type     | default value |
 |:---------|:--------------|
 | `object` | N/A           |
 
-`whiteList` is an object containing NodeType as keys and properties as values.
+`allowList` is an object containing NodeType as keys and properties as values.
 
 ```js
 {

--- a/index.js
+++ b/index.js
@@ -9,14 +9,15 @@
  */
 'use strict';
 
-const createWhitelist = require('./lib/create-whitelist');
-const cloneWithWhitelist = require('./lib/clone-ast');
+const createAllowlist = require('./lib/create-allowlist');
+const cloneWithAllowlist = require('./lib/clone-ast');
 
 function createCloneFunction (options) {
-  return cloneWithWhitelist(createWhitelist(options));
+  return cloneWithAllowlist(createAllowlist(options));
 }
 
 const espurify = createCloneFunction();
 espurify.customize = createCloneFunction;
-espurify.cloneWithWhitelist = cloneWithWhitelist;
+espurify.cloneWithAllowlist = cloneWithAllowlist;
+espurify.cloneWithWhitelist = cloneWithAllowlist;
 module.exports = espurify;

--- a/lib/clone-ast.js
+++ b/lib/clone-ast.js
@@ -1,15 +1,15 @@
 'use strict';
 
-module.exports = function cloneWithWhitelist (astWhiteList) {
-  const whitelist = Object.keys(astWhiteList).reduce(function (props, key) {
-    const propNames = astWhiteList[key];
+module.exports = function cloneWithAllowlist (astAllowList) {
+  const allowlist = Object.keys(astAllowList).reduce(function (props, key) {
+    const propNames = astAllowList[key];
     const prepend = (propNames.indexOf('type') === -1) ? ['type'] : [];
     props[key] = prepend.concat(propNames || []);
     return props;
   }, {});
 
   function cloneNodeOrObject (clone, obj, seen) {
-    const props = obj.type ? whitelist[obj.type] : null;
+    const props = obj.type ? allowlist[obj.type] : null;
     if (props) {
       return cloneNode(clone, obj, props, seen);
     } else {

--- a/lib/create-allowlist.js
+++ b/lib/create-allowlist.js
@@ -2,7 +2,7 @@
 
 const astProps = require('./ast-properties');
 
-module.exports = function createWhitelist (options) {
+module.exports = function createAllowlist (options) {
   const opts = options || {};
   const defaultProps = astProps(opts.ecmaVersion);
   let typeName, i, len;

--- a/test/test.js
+++ b/test/test.js
@@ -280,7 +280,7 @@ function traverse (object, currentKey, visitor) {
   }
 }
 
-describe('cloneWithWhitelist', function () {
+describe('cloneWithAllowlist', function () {
   let ast;
   beforeEach(function () {
     const code = fs.readFileSync(path.join(__dirname, 'fixtures', 'CounterContainer.jsx'), 'utf8');
@@ -294,12 +294,12 @@ describe('cloneWithWhitelist', function () {
     });
     ast = babelAst.program;
   });
-  it('complete whitelist', function () {
-    const astWhiteList = Object.keys(babelTypes.BUILDER_KEYS).reduce(function (props, key) {
+  it('complete allowlist', function () {
+    const astAllowList = Object.keys(babelTypes.BUILDER_KEYS).reduce(function (props, key) {
       props[key] = ['type'].concat(babelTypes.BUILDER_KEYS[key]);
       return props;
     }, {});
-    const purifyAst = espurify.cloneWithWhitelist(astWhiteList);
+    const purifyAst = espurify.cloneWithAllowlist(astAllowList);
     const purified = purifyAst(ast);
     traverse(purified, null, function (node, key) {
       assert.notEqual(key, 'loc');
@@ -308,7 +308,7 @@ describe('cloneWithWhitelist', function () {
     });
   });
   it('babel.types.BUILDER_KEYS', function () {
-    const purifyAst = espurify.cloneWithWhitelist(babelTypes.BUILDER_KEYS);
+    const purifyAst = espurify.cloneWithAllowlist(babelTypes.BUILDER_KEYS);
     const purified = purifyAst(ast);
     traverse(purified, null, function (node, key) {
       assert.notEqual(key, 'loc');


### PR DESCRIPTION
`espurify.cloneWithWhitelist` is still exported but deprecated in favor of more inclusive language and will be removed from future releases.
