### PR TITLE
feat: introduce `espurify.purifyAst` as an alias of default function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * [Provide ecmaVersion option to make cloned AST conform to each annual estree spec](https://github.com/estools/espurify/pull/26)
   * set default ecmaVersion to 2022
 
+* [Introduce `espurify.purifyAst` as an alias of default function](https://github.com/estools/espurify/pull/28/files)
+
 * [Rename all WhiteList to AllowList in favor of more inclusive language](https://github.com/estools/espurify/pull/27)
 
 * [Support ES2022 grammar](https://github.com/estools/espurify/commit/f80cfb6f2cc0a44ea4d971312bb52ce449b4c070)
@@ -22,9 +24,13 @@
 
 #### Breaking Changes
 
-This release will not affect most users. Just Two may-affect changes below.
+This release will not affect most users immediately. There are three notable changes.
 
-1. Some properties will appear to purified AST since default ecmaVersion is changed from 2018 to 2022 which added some properties to existing Nodes, may affect tree deep-equality.
+1. `espurify` function is still exported as default but deprecated in favor of named exports aiming ESM era, and will be removed in future major releases. Please use `espurify.purifyAst` instead.
+
+2. `espurify.cloneWithWhitelist` is still exported but deprecated in favor of more inclusive language and will be removed in future major releases. Please use `espurify.cloneWithAllowlist` instead.
+
+3. Some new properties will appear in purified AST and may affect deep-equality of the tree, since default ecmaVersion is changed from 2018 to 2022 which add some properties to existing Nodes.
 
 ```diff
 -  CallExpression: ['type', 'callee', 'arguments'],
@@ -40,8 +46,6 @@ To make espurify's behavior same as v2, please use `espurify.customize` function
 const purify = espurify.customize({ ecmaVersion: 2018 });
 const clonedAst = purify(originalAst);
 ```
-
-2. `espurify.cloneWithWhitelist` is still exported but deprecated in favor of more inclusive language and will be removed from future releases.
 
 
 ### [2.1.1](https://github.com/estools/espurify/releases/tag/v2.1.1) (2021-03-29)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Clone AST without extra properties
 API
 ---------------------------------------
 
-### const purifiedAstClone = espurify(originalAst)
+### const purifiedAstClone = espurify.purifyAst(originalAst)
+(note: using `espurify` as a default exported function is deprecated in favor of named exports aiming ESM era, and will be removed from future releases)
 
 Returns new clone of `originalAst` but without extra properties.
 
@@ -102,7 +103,7 @@ EXAMPLE
 ---------------------------------------
 
 ```javascript
-const espurify = require('.');
+const espurify = require('espurify');
 const estraverse = require('estraverse');
 const acorn = require('acorn');
 const syntax = estraverse.Syntax;
@@ -128,7 +129,7 @@ estraverse.replace(originalAst, {
 
 
 // purify AST
-const purifiedClone = espurify(originalAst);
+const purifiedClone = espurify.purifyAst(originalAst);
 
 
 // Extra properties are eliminated from cloned AST

--- a/index.js
+++ b/index.js
@@ -16,7 +16,11 @@ function createCloneFunction (options) {
   return cloneWithAllowlist(createAllowlist(options));
 }
 
+/**
+ * @deprecated since version 3.0.0. Use `espurify.purifyAst` instead.
+ */
 const espurify = createCloneFunction();
+espurify.purifyAst = createCloneFunction();
 espurify.customize = createCloneFunction;
 espurify.cloneWithAllowlist = cloneWithAllowlist;
 /**

--- a/test/test.js
+++ b/test/test.js
@@ -37,7 +37,7 @@ describe('eliminate extra properties from AST output', function () {
 
   it('eliminate tokens and raw', function () {
     const ast = esprima.parse('assert("foo")', { tolerant: true, tokens: true, raw: true });
-    const purified = espurify(ast);
+    const purified = espurify.purifyAst(ast);
 
     assert.deepEqual(ast, {
       type: 'Program',
@@ -87,7 +87,7 @@ describe('eliminate extra properties from AST output', function () {
 
   it('eliminate range', function () {
     const ast = esprima.parse('assert("foo")', { tolerant: true, range: true });
-    const purified = espurify(ast);
+    const purified = espurify.purifyAst(ast);
     assert.deepEqual(ast, {
       type: 'Program',
       sourceType: 'script',
@@ -137,7 +137,7 @@ describe('eliminate extra properties from AST output', function () {
 
   it('eliminate loc', function () {
     const ast = esprima.parse('assert("foo")', { tolerant: true, loc: true });
-    const purified = espurify(ast);
+    const purified = espurify.purifyAst(ast);
 
     assert.deepEqual(ast, {
       type: 'Program',
@@ -232,7 +232,7 @@ describe('eliminate extra properties from AST output', function () {
         }
       }
     });
-    const purified = espurify(ast);
+    const purified = espurify.purifyAst(ast);
 
     assert.deepEqual(ast, {
       type: 'Program',
@@ -383,7 +383,7 @@ describe('dealing with circular references in AST', function () {
     };
     expStmt.parent = program;
 
-    assert.deepEqual(espurify(program), {
+    assert.deepEqual(espurify.purifyAst(program), {
       type: 'Program',
       sourceType: 'script',
       body: [
@@ -496,6 +496,6 @@ describe('dealing with circular references in AST', function () {
     expected.right.properties[1].parent = expected.right;
     expected.right.properties[1].value.parent = expected.right.properties[1];
 
-    assert.deepEqual(espurify(root), expected);
+    assert.deepEqual(espurify.purifyAst(root), expected);
   });
 });


### PR DESCRIPTION
`espurify` function is still exported as default but deprecated in favor of named exports aiming ESM era, and will be removed in future major releases. Please use `espurify.purifyAst` instead.
